### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "High performance implementations of the Mittag-Leffler function"
 keywords = ["mittag-leffler", "special-functions"]
 categories = ["algorithms", "science"]
 readme = "README.md"
-homepage = "https://github.com/alexfikl/mittagleffler"
+repository = "https://github.com/alexfikl/mittagleffler"
 license = "MIT"
 exclude = [
     ".github/*",


### PR DESCRIPTION
According to the [manifset](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is preferable.  More explanation https://github.com/szabgab/rust-digger/issues/91